### PR TITLE
Added forgot password feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,8 @@ import Settings from './pages/Settings'
 import Login from './pages/Login'
 import Register from './pages/Register'
 import NotFound from './pages/NotFound'
+import ForgotPassword from './pages/ForgotPassword'
+import ResetPassword from './pages/ResetPassword'
 const ProtectedRoute = ({ children }) => {
   const { user } = useAuth()
   
@@ -46,6 +48,8 @@ function App() {
       <Route path="/" element={<AuthLayout />}>
         <Route path="login" element={<Login />} />
         <Route path="register" element={<Register />} />
+        <Route path="forgot-password" element={<ForgotPassword/>}/>
+        <Route path="reset-password" element={<ResetPassword/>}/>
       </Route>
       
       {/* Protected routes */}

--- a/src/pages/ForgotPassword.jsx
+++ b/src/pages/ForgotPassword.jsx
@@ -1,0 +1,43 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
+const ForgotPassword = () => {
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const navigate = useNavigate();
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+
+    const storedUsers = JSON.parse(localStorage.getItem("users")) || [];
+    const userExists = storedUsers.find((u) => u.email === email);
+
+    if (userExists) {
+      navigate(`/reset-password?email=${encodeURIComponent(email)}`);
+    } else {
+      setError("Email not found. Please check again.");
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Forgot Password</h2>
+      <form onSubmit={handleSubmit}>
+        <input
+          type="email"
+          placeholder="Enter your email"
+          className="input w-full mb-2"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        <button type="submit" className="btn btn-primary w-full">
+          Continue
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ForgotPassword;

--- a/src/pages/Login.jsx
+++ b/src/pages/Login.jsx
@@ -28,19 +28,26 @@ const Login = () => {
   return (
     <div className="card p-6 w-full animate-fadeIn">
       <div className="text-center mb-6">
-        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">Welcome Back</h1>
-        <p className="text-neutral-600 dark:text-neutral-400">Sign in to your MindJournal account</p>
+        <h1 className="text-2xl font-bold text-neutral-900 dark:text-white mb-2">
+          Welcome Back
+        </h1>
+        <p className="text-neutral-600 dark:text-neutral-400">
+          Sign in to your MindJournal account
+        </p>
       </div>
-      
+
       {error && (
         <div className="mb-4 p-3 bg-red-100 dark:bg-red-900/30 text-red-800 dark:text-red-200 rounded-lg text-sm">
           {error}
         </div>
       )}
-      
+
       <form onSubmit={handleSubmit} className="space-y-4">
         <div>
-          <label htmlFor="email" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+          <label
+            htmlFor="email"
+            className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1"
+          >
             Email
           </label>
           <div className="relative">
@@ -58,9 +65,12 @@ const Login = () => {
             />
           </div>
         </div>
-        
+
         <div>
-          <label htmlFor="password" className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1">
+          <label
+            htmlFor="password"
+            className="block text-sm font-medium text-neutral-700 dark:text-neutral-300 mb-1"
+          >
             Password
           </label>
           <div className="relative">
@@ -78,24 +88,35 @@ const Login = () => {
             />
           </div>
         </div>
-        
+        <div className="text-right text-sm">
+          <Link
+            to="/forgot-password"
+            className="text-primary-600 dark:text-primary-400 hover:underline"
+          >
+            Forgot Password?
+          </Link>
+        </div>
+
         <button
           type="submit"
           disabled={loading}
           className="btn btn-primary w-full"
         >
-          {loading ? 'Signing in...' : 'Sign in'}
+          {loading ? "Signing in..." : "Sign in"}
         </button>
       </form>
-      
+
       <div className="mt-6 text-center text-sm text-neutral-600 dark:text-neutral-400">
-        Don't have an account?{' '}
-        <Link to="/register" className="font-medium text-primary-600 dark:text-primary-400 hover:text-primary-500">
+        Don't have an account?{" "}
+        <Link
+          to="/register"
+          className="font-medium text-primary-600 dark:text-primary-400 hover:text-primary-500"
+        >
           Create an account
         </Link>
       </div>
     </div>
-  )
+  );
 }
 
 export default Login

--- a/src/pages/ResetPassword.jsx
+++ b/src/pages/ResetPassword.jsx
@@ -1,0 +1,65 @@
+import { useState, useEffect } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
+
+const ResetPassword = () => {
+  const [searchParams] = useSearchParams();
+  const navigate = useNavigate();
+  const [newPassword, setNewPassword] = useState("");
+  const [email, setEmail] = useState("");
+  const [error, setError] = useState("");
+  const [success, setSuccess] = useState(false);
+
+  useEffect(() => {
+    const emailFromQuery = searchParams.get("email");
+    if (!emailFromQuery) {
+      navigate("/forgot-password");
+    } else {
+      setEmail(emailFromQuery);
+    }
+  }, [navigate, searchParams]);
+
+  const handleReset = (e) => {
+    e.preventDefault();
+
+    const storedUsers = JSON.parse(localStorage.getItem("users")) || [];
+    const userIndex = storedUsers.findIndex((u) => u.email === email);
+
+    if (userIndex === -1) {
+      setError("User not found.");
+      return;
+    }
+
+    storedUsers[userIndex].password = newPassword;
+    localStorage.setItem("users", JSON.stringify(storedUsers));
+
+    setSuccess(true);
+    setTimeout(() => navigate("/login"), 1500);
+  };
+
+  return (
+    <div>
+      <h2 className="text-xl font-semibold mb-4">Reset Password</h2>
+      <form onSubmit={handleReset}>
+        <input
+          type="password"
+          placeholder="Enter new password"
+          className="input w-full mb-2"
+          value={newPassword}
+          onChange={(e) => setNewPassword(e.target.value)}
+          required
+        />
+        {error && <p className="text-red-500 text-sm">{error}</p>}
+        {success && (
+          <p className="text-green-500 text-sm">
+            Password updated! Redirecting...
+          </p>
+        )}
+        <button type="submit" className="btn btn-primary w-full">
+          Reset Password
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ResetPassword;


### PR DESCRIPTION
What I’ve done:
Added a new Reset Password page.

Implemented functionality to:
Accept a new password input.
Update password stored in localstorage.
Show success and error messages.
Redirect after successful reset.

Notes:
This works with the current localstorage-based auth.

No backend involved — changes apply on the same device only. (following the current auth flow)