### PR TITLE
📚 Added CODE_OF_CONDUCT.md [Closes #36]

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,73 @@
+# Contributor Covenant Code of Conduct
+
+## 👋 Our Pledge
+
+We as members, contributors, and leaders of the MindJournal project pledge to make participation in our community a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, caste, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+---
+
+## ✅ Our Standards
+
+Examples of behavior that contributes to a positive environment for our community include:
+
+- 💬 Demonstrating empathy and kindness toward other people  
+- 🧏‍♀️ Being respectful of differing opinions, viewpoints, and experiences  
+- 🙌 Giving and gracefully accepting constructive feedback  
+- 🤝 Taking responsibility and apologizing to those affected by our mistakes  
+- 🌱 Focusing on what is best for the community overall
+
+Examples of unacceptable behavior include:
+
+- ❌ Trolling, insulting or derogatory comments, and personal or political attacks  
+- ❌ Public or private harassment  
+- ❌ Publishing others' private information (such as a physical or email address) without explicit permission  
+- ❌ Other conduct which could reasonably be considered inappropriate in a professional setting
+
+---
+
+## 🛠 Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, or harmful.
+
+Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned with this Code of Conduct, and will communicate reasons for moderation decisions when appropriate.
+
+---
+
+## 📍 Scope
+
+This Code of Conduct applies within all project spaces, including GitHub repositories, issues, pull requests, discussions, and any other online or offline space where an individual is representing the project.
+
+Representation of a project may include use of an official project email address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
+
+---
+
+## 🚨 Enforcement
+
+If you experience or witness unacceptable behavior, please report it by opening a GitHub issue or privately contacting the maintainers.
+
+All project maintainers are obligated to respect the privacy and security of the reporter of any incident.
+
+---
+
+## 🧾 Enforcement Guidelines
+
+Project maintainers will follow these guidelines in determining the consequences for any action they deem in violation of this Code of Conduct:
+
+1. **Correction**
+2. **Warning**
+3. **Temporary Ban**
+4. **Permanent Ban**
+
+---
+
+## 🌐 Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org/version/2/1/code_of_conduct), version 2.1.
+
+---
+
+## 🙋 Note for GSSoC Participants
+
+HonorBox is part of **GirlScript Summer of Code (GSSoC 2025)**. All contributors — especially first-time open-source participants — are encouraged to follow this Code of Conduct to maintain a collaborative and inclusive space for learning and growth.


### PR DESCRIPTION
## 📄 Description
Added a standard Contributor Covenant Code of Conduct file (CODE_OF_CONDUCT.md) to define community guidelines for respectful collaboration and inclusive behavior.

This is especially important since this project is a part of GirlScript Summer of Code (GSSoC 2025).

---

### 🔗 Related Issue
Closes #36 