### PR TITLE
Feature: Context-Aware AI ChatBot for Journal Entries

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -14,6 +14,9 @@
         "dotenv": "^17.2.1",
         "express": "^5.1.0",
         "mongoose": "^8.16.4"
+      },
+      "devDependencies": {
+        "nodemon": "^3.1.10"
       }
     },
     "node_modules/@mongodb-js/saslprep": {
@@ -53,6 +56,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/anymatch": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.3.tgz",
+      "integrity": "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "normalize-path": "^3.0.0",
+        "picomatch": "^2.0.4"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
@@ -68,6 +85,26 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/binary-extensions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.3.0.tgz",
+      "integrity": "sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/body-parser": {
@@ -88,6 +125,30 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
+      "integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/bson": {
@@ -137,6 +198,31 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/chokidar": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.6.0.tgz",
+      "integrity": "sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "anymatch": "~3.1.2",
+        "braces": "~3.0.2",
+        "glob-parent": "~5.1.2",
+        "is-binary-path": "~2.1.0",
+        "is-glob": "~4.0.1",
+        "normalize-path": "~3.0.0",
+        "readdirp": "~3.6.0"
+      },
+      "engines": {
+        "node": ">= 8.10.0"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.2"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -148,6 +234,13 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/content-disposition": {
       "version": "1.0.0",
@@ -379,6 +472,19 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/finalhandler": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-2.1.0.tgz",
@@ -471,6 +577,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -517,6 +638,19 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -527,6 +661,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/has-symbols": {
@@ -605,6 +749,13 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/ignore-by-default": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/ignore-by-default/-/ignore-by-default-1.0.1.tgz",
+      "integrity": "sha512-Ius2VYcGNk7T90CppJqcIkS5ooHUZyIQK+ClZfMfMNFEF9VSE73Fq+906u/CWu92x4gzZMWOwfFYckPObzdEbA==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -618,6 +769,52 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.10"
+      }
+    },
+    "node_modules/is-binary-path": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-2.1.0.tgz",
+      "integrity": "sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "binary-extensions": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
       }
     },
     "node_modules/is-promise": {
@@ -690,6 +887,19 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
+      "integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/mongodb": {
@@ -806,6 +1016,45 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/nodemon": {
+      "version": "3.1.10",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.1.10.tgz",
+      "integrity": "sha512-WDjw3pJ0/0jMFmyNDp3gvY2YizjLmmOUQo6DEBY+JgdvW/yQ9mEeSw6H5ythl5Ny2ytb7f9C2nIbjSxMNzbJXw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "chokidar": "^3.5.2",
+        "debug": "^4",
+        "ignore-by-default": "^1.0.1",
+        "minimatch": "^3.1.2",
+        "pstree.remy": "^1.1.8",
+        "semver": "^7.5.3",
+        "simple-update-notifier": "^2.0.0",
+        "supports-color": "^5.5.0",
+        "touch": "^3.1.0",
+        "undefsafe": "^2.0.5"
+      },
+      "bin": {
+        "nodemon": "bin/nodemon.js"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/nodemon"
+      }
+    },
+    "node_modules/normalize-path": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-3.0.0.tgz",
+      "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -866,6 +1115,19 @@
         "node": ">=16"
       }
     },
+    "node_modules/picomatch": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
+      "integrity": "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/proxy-addr": {
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -883,6 +1145,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
+      "license": "MIT"
+    },
+    "node_modules/pstree.remy": {
+      "version": "1.1.8",
+      "resolved": "https://registry.npmjs.org/pstree.remy/-/pstree.remy-1.1.8.tgz",
+      "integrity": "sha512-77DZwxQmxKnu3aR542U+X8FypNzbfJ+C5XQDk3uWjWxn6151aIMGthWYRXTqT1E5oJvg+ljaa2OJi+VfvCOQ8w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/punycode": {
@@ -933,6 +1202,19 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/readdirp": {
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
+      "integrity": "sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "picomatch": "^2.2.1"
+      },
+      "engines": {
+        "node": ">=8.10.0"
+      }
+    },
     "node_modules/router": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/router/-/router-2.2.0.tgz",
@@ -974,6 +1256,19 @@
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
+    },
+    "node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/send": {
       "version": "1.2.0",
@@ -1096,6 +1391,19 @@
       "integrity": "sha512-Rtlj66/b0ICeFzYTuNvX/EF1igRbbnGSvEyT79McoZa/DeGhMyC5pWKOEsZKnpkqtSeovd5FL/bjHWC3CIIvCQ==",
       "license": "MIT"
     },
+    "node_modules/simple-update-notifier": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/simple-update-notifier/-/simple-update-notifier-2.0.0.tgz",
+      "integrity": "sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/sparse-bitfield": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
@@ -1114,6 +1422,32 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1121,6 +1455,16 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/touch": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/touch/-/touch-3.1.1.tgz",
+      "integrity": "sha512-r0eojU4bI8MnHr8c5bNo7lJDdI2qXlWWJk6a9EAFG7vbhTjElYhBVS3/miuE0uOuoLdb8Mc/rVfsmm6eo5o9GA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "nodetouch": "bin/nodetouch.js"
       }
     },
     "node_modules/tr46": {
@@ -1148,6 +1492,13 @@
       "engines": {
         "node": ">= 0.6"
       }
+    },
+    "node_modules/undefsafe": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/undefsafe/-/undefsafe-2.0.5.tgz",
+      "integrity": "sha512-WxONCrssBM8TSPRqN5EmsjVrsv4A8X12J4ArBiiayv3DyyG3ZlIg6yysuuSYdZsVz3TKcTg2fd//Ujd4CHV1iA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,8 @@
   "main": "server.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "dev": "nodemon server.js"
   },
   "keywords": [],
   "author": "",
@@ -17,5 +18,8 @@
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
     "mongoose": "^8.16.4"
+  },
+  "devDependencies": {
+    "nodemon": "^3.1.10"
   }
 }

--- a/backend/routes/mindbot.js
+++ b/backend/routes/mindbot.js
@@ -4,15 +4,50 @@ import axios from 'axios';
 const router = express.Router();
 
 router.post('/mindbot', async (req, res) => {
-  const userMessage = req.body.message;
+  console.log('Received request for /mindbot with body:', JSON.stringify(req.body, null, 2));
+  const { message: userMessage, context: entry } = req.body;
+
+  let systemPrompt;
+
+  if (entry) {
+    let contextString = '';
+    try {
+      contextString += `Title: ${entry.title || 'Not specified'}\n`;
+      contextString += `Mood: ${entry.mood || 'Not specified'}\n`;
+      if (entry.activities && Array.isArray(entry.activities) && entry.activities.length > 0) {
+        contextString += `Activities: ${entry.activities.join(', ')}\n`;
+      }
+      if (entry.micro_goals && Array.isArray(entry.micro_goals) && entry.micro_goals.length > 0) {
+        contextString += `Goals:\n${entry.micro_goals.map(g => `- ${g.text} (${g.is_completed ? 'Completed' : 'Pending'})`).join('\n')}\n`;
+      }
+      contextString += `\nContent:\n---\n${entry.content || 'The user has not written anything yet.'}\n---`;
+    } catch (error) {
+      console.error('Error constructing context string:', error);
+      return res.status(500).json({ error: 'Failed to construct context string.', details: error.message });
+    }
+
+    systemPrompt = `You are MindBot-AI, an empathetic mental health assistant. Your primary task is to discuss the provided journal entry with the user.
+
+**Journal Entry Details:**
+${contextString}
+
+**Your Instructions:**
+-   **Focus exclusively** on the journal entry provided above.
+-   Engage with the user about their thoughts and feelings related to this specific entry.
+-   Be supportive, empathetic, and helpful.
+-   **Do not** mention that you are an AI.
+-   **Do not** refer to any "past entries" or previous conversations. Your knowledge is limited to this single entry.`;
+  } else {
+    systemPrompt = 'You are MindBot-AI, an empathetic mental health assistant. Respond to the user in a supportive and helpful manner.';
+  }
 
   try {
     const response = await axios.post(
       'https://openrouter.ai/api/v1/chat/completions',
       {
-        model: 'tngtech/deepseek-r1t2-chimera:free', // adjust to your preferred model
+        model: 'mistralai/mistral-7b-instruct:free', // Using a known stable model
         messages: [
-          { role: 'system', content: 'You are MindBot-AI, an empathetic mental health assistant.' },
+          { role: 'system', content: systemPrompt },
           { role: 'user', content: userMessage }
         ]
       },
@@ -28,8 +63,8 @@ router.post('/mindbot', async (req, res) => {
     res.json({ reply: aiReply });
 
   } catch (error) {
-    console.error(error.response?.data || error.message);
-    res.status(500).json({ error: 'OpenRouter call failed' });
+    console.error('Full error object from OpenRouter call:', error);
+    res.status(500).json({ error: 'OpenRouter call failed', details: error.message });
   }
 });
 

--- a/backend/server.js
+++ b/backend/server.js
@@ -3,8 +3,13 @@ import express from 'express';
 import dotenv from 'dotenv';
 import mindbotRoutes from './routes/mindbot.js';
 import cors from 'cors';
+import path from 'path';
+import { fileURLToPath } from 'url';
 
-dotenv.config();
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.dirname(__filename);
+
+dotenv.config({ path: path.resolve(__dirname, 'routes', '.env') });
 
 const app = express();
 app.use(express.json());

--- a/src/components/journal/EntryCard.jsx
+++ b/src/components/journal/EntryCard.jsx
@@ -1,6 +1,6 @@
-import { Link } from 'react-router-dom'
+import { Link, useOutletContext } from 'react-router-dom'
 import { format } from 'date-fns'
-import { FiEdit2, FiTrash2 } from 'react-icons/fi'
+import { FiMessageSquare, FiEdit2, FiTrash2 } from 'react-icons/fi'
 import MoodIcon from './MoodIcon'
 import { Goal } from 'lucide-react';
 

--- a/src/components/journal/EntryForm.jsx
+++ b/src/components/journal/EntryForm.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { useJournal } from '../../contexts/JournalContext';
 import { Check, Smile, Meh, Frown, UploadCloud, XCircle, Loader2, Trash2 } from 'lucide-react';
 import { FaRunning, FaBookOpen, FaPrayingHands, FaBriefcase, FaUsers } from 'react-icons/fa';
 import { marked } from "marked";
@@ -15,6 +16,7 @@ const moods = [
 ];
 
 const EntryForm = ({ onSubmit, initialData = {} }) => {
+  const { setActiveEntry } = useJournal();
   const [entryData, setEntryData] = useState({
     title: '',
     content: '',
@@ -197,6 +199,10 @@ const EntryForm = ({ onSubmit, initialData = {} }) => {
     setIsModalOpen(false);
     handleSaveEntry(generatedQuote);
   };
+
+  useEffect(() => {
+    setActiveEntry(entryData);
+  }, [entryData, setActiveEntry]);
 
   return (
     <>

--- a/src/layouts/MainLayout.jsx
+++ b/src/layouts/MainLayout.jsx
@@ -1,46 +1,71 @@
 import { useState, useEffect } from 'react'
-import { Outlet } from 'react-router-dom'
-import { JournalProvider } from '../contexts/JournalContext'
+import { Outlet, useLocation, useParams } from 'react-router-dom'
+import { JournalProvider, useJournal } from '../contexts/JournalContext'
 import MobileHeader from '../components/navigation/MobileHeader'
 import Sidebar from '../components/navigation/Sidebar'
 import QuoteLoader from '../components/loader/QuotesLoader'
+import MindChatFloat from '../pages/MindChatFloat'
 
-const MainLayout = () => {
-  const [isInitialLoading, setIsInitialLoading] = useState(true)
-  const [showContent, setShowContent] = useState(false)
-  
+const MainLayoutContent = () => {
+  const location = useLocation();
+  const params = useParams();
+  const { getEntry, activeEntry, loading } = useJournal();
+
+  const [chatContext, setChatContext] = useState(null);
+  const [isChatOpen, setIsChatOpen] = useState(false);
+
+  const isEntryDetailPage = location.pathname.includes('/journal/') && params.id && !location.pathname.endsWith('/edit');
+  const isEntryFormPage = location.pathname === '/journal/new' || location.pathname.endsWith('/edit');
+
   useEffect(() => {
-    const timer = setTimeout(() => {
-      setIsInitialLoading(false)
-      setTimeout(() => {
-        setShowContent(true)
-      }, 100)
-    }, 2000)
-    
-    return () => clearTimeout(timer)
-  }, [])
-  
-  if (isInitialLoading) {
-    return <QuoteLoader />
+    if (!loading) {
+      if (isEntryDetailPage) {
+        const entry = getEntry(params.id);
+        setChatContext(entry || null);
+      } else if (isEntryFormPage) {
+        setChatContext(activeEntry);
+      } else {
+        setChatContext(null);
+      }
+    }
+  }, [location.pathname, params.id, getEntry, activeEntry, loading]);
+
+  if (loading) {
+    return <QuoteLoader />;
   }
 
   return (
-    <JournalProvider>
-      <div className={`min-h-screen flex flex-col md:flex-row bg-neutral-50 dark:bg-neutral-900 transition-all duration-1000 ease-out ${
-        showContent ? 'opacity-100 translate-y-0' : 'opacity-0 translate-y-8'
-      }`}>
+    <>
+      <div className={`min-h-screen flex flex-col md:flex-row bg-neutral-50 dark:bg-neutral-900`}>
         <MobileHeader />
         
         <div className="hidden md:block md:w-64 lg:w-72">
           <Sidebar />
         </div>
         
-        <main className="flex-1 p-4 md:p-6 max-w-6xl mx-auto w-full">
-          <div className="pt-16 md:pt-0">
-            <Outlet />
-          </div>
-        </main>
+      <main className="flex-1 p-4 md:p-6 max-w-6xl mx-auto w-full">
+        <div className="pt-16 md:pt-0">
+          <Outlet />
+        </div>
+      </main>
       </div>
+      {(isEntryDetailPage || isEntryFormPage) && (
+      <MindChatFloat
+        entry={chatContext}
+        isOpen={isChatOpen}
+        setIsOpen={setIsChatOpen}
+        setEntry={setChatContext}
+      />
+      )}
+    </>
+  );
+};
+
+
+const MainLayout = () => {
+  return (
+    <JournalProvider>
+      <MainLayoutContent />
     </JournalProvider>
   )
 }

--- a/src/pages/MindChat.jsx
+++ b/src/pages/MindChat.jsx
@@ -48,8 +48,11 @@ function MindChat() {
   }
 };
 
-  const handleKeyPress = (e) => {
-    if (e.key === 'Enter') handleSend();
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSend();
+    }
   };
 
   useEffect(() => {
@@ -86,7 +89,7 @@ function MindChat() {
           placeholder="Type how you feel..."
           value={input}
           onChange={(e) => setInput(e.target.value)}
-          onKeyPress={handleKeyPress}
+          onKeyDown={handleKeyDown}
           className="flex-1 bg-[#2c2c2c] text-gray-200 rounded-full px-4 py-2 mr-2 outline-none focus:ring focus:border-teal-400"
         />
         <button

--- a/src/pages/MindChatFloat.jsx
+++ b/src/pages/MindChatFloat.jsx
@@ -1,0 +1,146 @@
+import React, { useState, useRef, useEffect } from 'react';
+import { FiSend, FiMessageSquare, FiX } from 'react-icons/fi';
+
+const MindChatFloat = ({ entry, isOpen, setIsOpen, setEntry }) => {
+  const [messages, setMessages] = useState([]);
+  const [input, setInput] = useState('');
+  const messagesEndRef = useRef(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      const initialMessage = entry
+        ? `Let's talk about this entry: "${entry.title}". What's on your mind?`
+        : "Hi there! I'm MindBot. How can I help you today?";
+      setMessages([{ sender: 'bot', text: initialMessage }]);
+    }
+  }, [isOpen, entry]);
+
+  const handleSend = async () => {
+    if (!input.trim()) return;
+
+    const userMessage = { sender: 'user', text: input.trim() };
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+
+    const typingMessage = { sender: 'bot', text: 'MindBot is typing...' };
+    setMessages(prev => [...prev, typingMessage]);
+
+    const contextForApi = entry ? {
+      title: entry.title,
+      content: entry.content,
+      mood: entry.mood,
+      activities: entry.activities,
+      micro_goals: entry.micro_goals,
+    } : null;
+
+    console.log('Sending to API with context:', contextForApi);
+
+    try {
+      const res = await fetch('http://localhost:5000/api/mindbot', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: input.trim(),
+          context: contextForApi,
+        }),
+      });
+
+      if (!res.ok) {
+        throw new Error(`Server responded with status ${res.status}`);
+      }
+
+      const data = await res.json();
+
+      if (!data.reply) {
+        throw new Error('No reply in JSON');
+      }
+
+      setMessages(prev => [...prev.slice(0, -1), { sender: 'bot', text: data.reply }]);
+
+    } catch (err) {
+      console.error('Error:', err);
+      setMessages(prev => [
+        ...prev.slice(0, -1),
+        { sender: 'bot', text: 'Sorry, I had trouble responding 💙' }
+      ]);
+    }
+  };
+
+  const handleKeyDown = (e) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages]);
+
+  const handleClose = () => {
+    setIsOpen(false);
+    if (setEntry) {
+      setEntry(null);
+    }
+  };
+
+  return (
+    <div className="fixed bottom-8 right-8 z-50">
+      {!isOpen ? (
+        <button
+          onClick={() => setIsOpen(true)}
+          className="bg-primary-600 text-white p-4 rounded-full shadow-lg hover:bg-primary-700 transition-transform transform hover:scale-110"
+          aria-label="Open MindBot"
+        >
+          <FiMessageSquare size={24} />
+        </button>
+      ) : (
+        <div className="w-96 h-[60vh] flex flex-col bg-white dark:bg-neutral-800 rounded-2xl shadow-2xl border border-neutral-200 dark:border-neutral-700">
+          <div className="flex justify-between items-center p-4 border-b border-neutral-200 dark:border-neutral-700">
+            <h3 className="font-bold text-lg text-neutral-900 dark:text-white">MindBot AI</h3>
+            <button onClick={handleClose} className="p-2 rounded-full hover:bg-neutral-100 dark:hover:bg-neutral-700">
+              <FiX size={20} className="text-neutral-600 dark:text-neutral-300" />
+            </button>
+          </div>
+          <div className="flex-1 overflow-y-auto p-4 space-y-4">
+            {messages.map((msg, idx) => (
+              <div
+                key={idx}
+                className={`flex ${msg.sender === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                <div
+                  className={`max-w-[85%] whitespace-pre-line px-4 py-2 rounded-xl text-sm ${
+                    msg.sender === 'user'
+                      ? 'bg-primary-600 text-white'
+                      : 'bg-neutral-200 dark:bg-neutral-700 text-neutral-800 dark:text-neutral-100'
+                  }`}
+                >
+                  {msg.text}
+                </div>
+              </div>
+            ))}
+            <div ref={messagesEndRef} />
+          </div>
+          <div className="p-4 flex items-center border-t border-neutral-200 dark:border-neutral-700">
+            <input
+              type="text"
+              placeholder="Ask about your entry..."
+              value={input}
+              onChange={(e) => setInput(e.target.value)}
+              onKeyDown={handleKeyDown}
+              className="flex-1 bg-neutral-100 dark:bg-neutral-700 text-neutral-900 dark:text-white rounded-full px-4 py-2 mr-2 outline-none focus:ring-2 focus:ring-primary-500"
+            />
+            <button
+              onClick={handleSend}
+              className="p-3 bg-primary-600 rounded-full text-white hover:bg-primary-700 transition"
+            >
+              <FiSend size={20} />
+            </button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default MindChatFloat;


### PR DESCRIPTION
## Description
This pull request introduces a major enhancement to the MindChat feature, adding context-aware companion for self-reflection. Now, when a user is viewing a journal entry, they can open the chat to have a conversation with an AI that has a deep understanding of that specific entry.

Fixes #60 
---

-   The AI automatically knows which entry the user is viewing, creating an intuitive conversation.
-   The journal is no longer a static page of text but a dynamic conversation.
-   An AI icon now floats in the bottom-right corner of the entry detail and entry form pages, making the chat easily accessible.
-   When the chat is opened from an entry page, it automatically "reads" the entry's content.

---

### Summary of Issues Resolved

This PR also resolves a series of challenging bugs that were affecting the application's stability and functionality:

-   Replaced the deprecated `onKeyPress` event with `onKeyDown` in all chat components to adhere to modern React standards.
-   Resolved a critical bug where the backend was not loading the `.env` file from the correct path, causing API key failures.
-   Rewrote the state management logic in the main layout and journal context to resolve a persistent bug where the chat would not update with the correct journal entry when navigating between pages.
-   The backend is now configured to run with `nodemon`, which will automatically restart the server on file changes, improving the development workflow.

---

### How to Test Locally

1.  **Get the OpenRouter API Key**:
    -   Go to [OpenRouter.ai](https://openrouter.ai/) and sign in.
    -   Navigate to your account settings and generate a new API key.
    -   In the `backend/routes` directory, create a file named `.env` and add the following:
        ```
        OPENROUTER_API_KEY=your_api_key_here
        ```

2.  **Run the Backend Server**:
    -   Open a terminal, to the `backend` directory.
    -   Run `npm install`
    -   Run `npm run dev` to start the server with `nodemon`.

3.  **Run the Frontend Application**:
    -   Open a new terminal, the root of the project.
    -   Run `npm install`
    -   Run `npm run dev` to start the frontend dev server.

4.  **Test the Feature**:
    -   Navigate to a journal entry's detail page.
    -   Click the floating chat icon in the bottom-right corner.
    -   The chat should open with a message referencing the entry's title.
    -   Ask questions about the entry to confirm that the AI's responses are context-aware.
    -   Navigate to a different entry and repeat the process to ensure the context updates correctly.
    
---

Screen Recording (feature tested):

https://github.com/user-attachments/assets/4ded953e-92d5-4dd3-b75e-0ac1bc053e0f

@efshaperveen : This PR is now fully tested and working correctly in the local environment. Please read the instructions below:

__Important__: The feature currently works by pointing the frontend to the local backend (`http://localhost:5000/api/mindbot`). The deployed backend at `https://mindjournal-backend.onrender.com` is still running the old backend code, so the context-aware features will not work with the live link until the latest changes from this PR are deployed.

__Action Required__: After merging this pull request, please redeploy the backend folder to Render. Once the new backend is live, the `fetch` URL in `src/components/mind-chat/MindChatFloat.jsx` and `src/pages/MindChat.jsx` should be updated from the local development endpoint to your production Render link.