### PR TITLE
feat: add mood heatmap with color legend and tooltip

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "react-hot-toast": "^2.5.2",
         "react-icons": "^5.5.0",
         "react-router-dom": "^6.22.3",
+        "react-tooltip": "^5.29.1",
         "recharts": "^3.1.0"
       },
       "devDependencies": {
@@ -892,6 +893,28 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
+    },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.3.tgz",
+      "integrity": "sha512-sGnvb5dmrJaKEZ+LDIpguvdX3bDlEllmv4/ClQ9awcmCZrlx5jQyyMWFM5kBI+EyNOCDDiKk8il0zeuX3Zlg/w==",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.3",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.3.tgz",
+      "integrity": "sha512-uZA413QEpNuhtb3/iIKoYMSK07keHPYeXF02Zhd6e213j+d1NamLix/mCLxBUDW/Gx52sPH2m+chlUsyaBs/Ag==",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.3",
+        "@floating-ui/utils": "^0.2.10"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.10",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.10.tgz",
+      "integrity": "sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ=="
     },
     "node_modules/@google/generative-ai": {
       "version": "0.24.1",
@@ -2228,6 +2251,11 @@
       "engines": {
         "node": ">= 6"
       }
+    },
+    "node_modules/classnames": {
+      "version": "2.5.1",
+      "resolved": "https://registry.npmjs.org/classnames/-/classnames-2.5.1.tgz",
+      "integrity": "sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow=="
     },
     "node_modules/clsx": {
       "version": "2.1.1",
@@ -5654,6 +5682,19 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-tooltip": {
+      "version": "5.29.1",
+      "resolved": "https://registry.npmjs.org/react-tooltip/-/react-tooltip-5.29.1.tgz",
+      "integrity": "sha512-rmJmEb/p99xWhwmVT7F7riLG08wwKykjHiMGbDPloNJk3tdI73oHsVOwzZ4SRjqMdd5/xwb/4nmz0RcoMfY7Bw==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.1",
+        "classnames": "^2.3.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.14.0",
+        "react-dom": ">=16.14.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "react-hot-toast": "^2.5.2",
     "react-icons": "^5.5.0",
     "react-router-dom": "^6.22.3",
+    "react-tooltip": "^5.29.1",
     "recharts": "^3.1.0"
   },
   "devDependencies": {

--- a/src/App.css
+++ b/src/App.css
@@ -40,3 +40,7 @@
 .read-the-docs {
   color: #888;
 }
+
+.calming-bg {
+  background: linear-gradient(to right, #cce7ff, #e8dfff);
+}

--- a/src/components/dashboard/Heatmap.jsx
+++ b/src/components/dashboard/Heatmap.jsx
@@ -1,0 +1,345 @@
+import { useState, useMemo } from "react";
+import {
+  format,
+  subDays,
+  startOfWeek,
+  endOfWeek,
+  startOfMonth,
+  endOfMonth,
+  startOfYear,
+  endOfYear,
+  eachDayOfInterval,
+} from "date-fns";
+import {
+  FiCalendar,
+  FiChevronDown,
+  FiTrendingUp,
+  FiChevronLeft,
+  FiChevronRight,
+} from "react-icons/fi";
+import { Tooltip } from "react-tooltip";
+import { useJournal } from "../../contexts/JournalContext";
+
+const Heatmap = () => {
+  const [filter, setFilter] = useState("month");
+  const [showFilterDropdown, setShowFilterDropdown] = useState(false);
+  const [selectedYear, setSelectedYear] = useState(new Date().getFullYear());
+  const [selectedMonth, setSelectedMonth] = useState(new Date().getMonth());
+  const [selectedWeek, setSelectedWeek] = useState(0);
+
+  const { entries } = useJournal();
+
+  const moodIntensity = {
+    great: 5,
+    good: 4,
+    okay: 3,
+    bad: 2,
+    awful: 1,
+  };
+
+  const aggregateMoods = (moods) => {
+    if (!moods || moods.length === 0) return null;
+    const total = moods.reduce((sum, mood) => sum + moodIntensity[mood], 0);
+    const avg = total / moods.length;
+    if (avg >= 4.5) return "great";
+    if (avg >= 3.5) return "good";
+    if (avg >= 2.5) return "okay";
+    if (avg >= 1.5) return "bad";
+    return "awful";
+  };
+
+  const processJournalData = () => {
+    const data = {};
+    entries.forEach((entry) => {
+      const dateString = format(new Date(entry.createdAt), "yyyy-MM-dd");
+      if (!data[dateString]) {
+        data[dateString] = { moods: [], entries: [], entryCount: 0 };
+      }
+      if (entry.mood) {
+        data[dateString].moods.push(entry.mood);
+        data[dateString].entries.push(entry);
+        data[dateString].entryCount++;
+      }
+    });
+    Object.values(data).forEach((d) => {
+      d.aggregatedMood = aggregateMoods(d.moods);
+    });
+    return data;
+  };
+
+  const journalData = processJournalData();
+
+  const getMoodColor = (mood) => {
+    switch (mood) {
+      case "great":
+        return "bg-emerald-500 dark:bg-emerald-400";
+      case "good":
+        return "bg-blue-500 dark:bg-blue-400";
+      case "okay":
+        return "bg-slate-400 dark:bg-slate-500";
+      case "bad":
+        return "bg-amber-500 dark:bg-amber-400";
+      case "awful":
+        return "bg-rose-500 dark:bg-rose-400";
+      default:
+        return "bg-gray-200 dark:bg-gray-700";
+    }
+  };
+
+  const getMoodLabel = (mood) => {
+    switch (mood) {
+      case "great":
+        return "Great";
+      case "good":
+        return "Good";
+      case "okay":
+        return "Okay";
+      case "bad":
+        return "Bad";
+      case "awful":
+        return "Awful";
+      default:
+        return "No Entry";
+    }
+  };
+
+  const getDateRange = () => {
+    const today = new Date();
+    if (filter === "week") {
+      const start = startOfWeek(subDays(today, selectedWeek * 7));
+      return { start, end: endOfWeek(start) };
+    }
+    if (filter === "month") {
+      const start = new Date(selectedYear, selectedMonth, 1);
+      return { start, end: endOfMonth(start) };
+    }
+    if (filter === "year") {
+      return {
+        start: startOfYear(new Date(selectedYear, 0, 1)),
+        end: endOfYear(new Date(selectedYear, 11, 31)),
+      };
+    }
+    return { start: startOfMonth(today), end: today };
+  };
+
+  const calendarData = useMemo(() => {
+    const { start, end } = getDateRange();
+    const days = eachDayOfInterval({ start, end });
+    return days.map((day) => {
+      const dateString = format(day, "yyyy-MM-dd");
+      const moodData = journalData[dateString];
+      return {
+        date: day,
+        dateString,
+        mood: moodData?.aggregatedMood || null,
+        hasData: !!moodData,
+        entries: moodData?.entries || [],
+        moods: moodData?.moods || [],
+      };
+    });
+  }, [filter, selectedYear, selectedMonth, selectedWeek, journalData]);
+
+  const weeksData = useMemo(() => {
+    const weeks = [];
+    let currentWeek = [];
+    calendarData.forEach((day, i) => {
+      currentWeek.push(day);
+      if ((i + 1) % 7 === 0 || i === calendarData.length - 1) {
+        weeks.push(currentWeek);
+        currentWeek = [];
+      }
+    });
+    return weeks;
+  }, [calendarData]);
+
+  const getCellSize = () => {
+    if (filter === "week") return "w-8 h-8 sm:w-10 sm:h-10";
+    if (filter === "month") return "w-5 h-5 sm:w-6 sm:h-6";
+    if (filter === "year") return "w-2 h-2 sm:w-3 sm:h-3";
+    return "w-5 h-5";
+  };
+
+  const moodStats = useMemo(() => {
+    const stats = { great: 0, good: 0, okay: 0, bad: 0, awful: 0, total: 0 };
+    calendarData.forEach((day) => {
+      if (day.mood) {
+        stats[day.mood]++;
+        stats.total++;
+      }
+    });
+    return stats;
+  }, [calendarData]);
+
+  const navigatePrevious = () => {
+    if (filter === "week") setSelectedWeek((prev) => prev + 1);
+    if (filter === "month") {
+      if (selectedMonth === 0) {
+        setSelectedMonth(11);
+        setSelectedYear((y) => y - 1);
+      } else setSelectedMonth((m) => m - 1);
+    }
+    if (filter === "year") setSelectedYear((y) => y - 1);
+  };
+
+  const navigateNext = () => {
+    if (filter === "week") setSelectedWeek((prev) => Math.max(0, prev - 1));
+    if (filter === "month") {
+      if (selectedMonth === 11) {
+        setSelectedMonth(0);
+        setSelectedYear((y) => y + 1);
+      } else setSelectedMonth((m) => m + 1);
+    }
+    if (filter === "year") setSelectedYear((y) => y + 1);
+  };
+
+  const getCurrentSelection = () => {
+    if (filter === "week")
+      return `Week of ${format(subDays(new Date(), selectedWeek * 7), "MMM d, yyyy")}`;
+    if (filter === "month")
+      return `${format(new Date(selectedYear, selectedMonth), "MMMM yyyy")}`;
+    if (filter === "year") return `${selectedYear}`;
+    return "Current";
+  };
+
+  return (
+    <div className="w-full p-6 bg-white dark:bg-neutral-800 rounded-lg shadow-sm border border-neutral-200 dark:border-neutral-700 animate-fadeIn">
+      {/* Header */}
+      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between mb-6 gap-4">
+        <div className="flex items-center space-x-3">
+          <div className="p-2 bg-primary-100 dark:bg-primary-800 text-primary-900 dark:text-primary-100 rounded-lg">
+            <FiTrendingUp size={20} />
+          </div>
+          <div>
+            <h2 className="text-xl font-lora font-semibold text-neutral-900 dark:text-white">
+              Mood Heatmap
+            </h2>
+            <p className="text-neutral-600 dark:text-neutral-400 text-sm">
+              Visualize your emotional patterns over time
+            </p>
+          </div>
+        </div>
+        {/* Filter & Navigation */}
+        <div className="flex items-center space-x-3">
+          <div className="relative">
+            <button
+              onClick={() => setShowFilterDropdown(!showFilterDropdown)}
+              className="flex items-center space-x-2 px-3 py-2 text-sm bg-neutral-50 dark:bg-neutral-700 text-neutral-700 dark:text-neutral-300 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-600 border"
+            >
+              <FiCalendar size={14} />
+              <span>{filter.charAt(0).toUpperCase() + filter.slice(1)}</span>
+              <FiChevronDown
+                size={14}
+                className={`transition-transform ${showFilterDropdown ? "rotate-180" : ""}`}
+              />
+            </button>
+            {showFilterDropdown && (
+              <div className="absolute right-0 top-full mt-1 bg-white dark:bg-neutral-800 border rounded-lg shadow-lg z-10">
+                {["week", "month", "year"].map((option) => (
+                  <button
+                    key={option}
+                    onClick={() => {
+                      setFilter(option);
+                      setShowFilterDropdown(false);
+                    }}
+                    className={`block w-full px-3 py-2 text-sm hover:bg-neutral-50 dark:hover:bg-neutral-700 ${
+                      filter === option ? "text-green-600 font-medium" : ""
+                    }`}
+                  >
+                    {option.charAt(0).toUpperCase() + option.slice(1)}
+                  </button>
+                ))}
+              </div>
+            )}
+          </div>
+          <button onClick={navigatePrevious} className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700">
+            <FiChevronLeft size={16} />
+          </button>
+          <div className="px-3 py-1 bg-neutral-50 dark:bg-neutral-700 rounded-lg text-sm font-medium">
+            {getCurrentSelection()}
+          </div>
+          <button
+            onClick={navigateNext}
+            disabled={filter === "week" && selectedWeek === 0}
+            className="p-2 rounded-lg hover:bg-neutral-100 dark:hover:bg-neutral-700 disabled:opacity-50"
+          >
+            <FiChevronRight size={16} />
+          </button>
+        </div>
+      </div>
+
+      {/* Mood Stats */}
+      <div className="grid grid-cols-5 gap-3 mb-6">
+        {["great", "good", "okay", "bad", "awful"].map((mood) => (
+          <div
+            key={mood}
+            className="rounded-lg p-3 border border-neutral-200 dark:border-neutral-700"
+          >
+            <div className="flex items-center space-x-2 mb-1">
+              <div className={`w-2 h-2 rounded-full ${getMoodColor(mood)}`}></div>
+              <span className="text-xs text-neutral-600 dark:text-neutral-400">
+                {getMoodLabel(mood)}
+              </span>
+            </div>
+            <div className="text-lg font-bold text-neutral-900 dark:text-white">
+              {moodStats[mood]}
+            </div>
+            <div className="text-xs text-neutral-500 dark:text-neutral-400">
+              {moodStats.total > 0
+                ? Math.round((moodStats[mood] / moodStats.total) * 100)
+                : 0}
+              %
+            </div>
+          </div>
+        ))}
+      </div>
+
+      {/* Heatmap */}
+      <div className="flex justify-center">
+        <div className="grid grid-flow-col gap-1 auto-cols-max">
+          {weeksData.map((week, i) => (
+            <div key={i} className="grid grid-flow-row gap-1 auto-rows-max">
+              {week.map((day) => {
+                const tooltipContent = day.hasData
+                  ? `<div><strong>${format(day.date, "MMM d, yyyy")}</strong><br/>Mood: ${getMoodLabel(
+                      day.mood
+                    )}<br/>Entries: ${day.moods.join(", ")}</div>`
+                  : `<div>${format(day.date, "MMM d, yyyy")}<br/>No Entry</div>`;
+
+                return (
+                  <div
+                    key={day.dateString}
+                    data-tooltip-id={`tooltip-${day.dateString}`}
+                    data-tooltip-html={tooltipContent}
+                    className={`${getCellSize()} rounded-sm transition-all duration-200 hover:scale-110 cursor-pointer ${getMoodColor(
+                      day.mood
+                    )}`}
+                  >
+                    <Tooltip id={`tooltip-${day.dateString}`} className="max-w-xs text-sm" />
+                  </div>
+                );
+              })}
+            </div>
+          ))}
+        </div>
+      </div>
+
+      {/* Color Legend */}
+      <div className="flex justify-center mt-4 space-x-4">
+        {[
+          { label: "Great", color: "bg-emerald-500 dark:bg-emerald-400" },
+          { label: "Good", color: "bg-blue-500 dark:bg-blue-400" },
+          { label: "Okay", color: "bg-slate-400 dark:bg-slate-500" },
+          { label: "Bad", color: "bg-amber-500 dark:bg-amber-400" },
+          { label: "Awful", color: "bg-rose-500 dark:bg-rose-400" },
+        ].map((item) => (
+          <div key={item.label} className="flex items-center space-x-2">
+            <div className={`w-4 h-4 rounded-sm ${item.color}`} />
+            <span className="text-sm text-neutral-700 dark:text-neutral-300">{item.label}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default Heatmap;

--- a/src/index.css
+++ b/src/index.css
@@ -58,6 +58,21 @@
   .card {
     @apply bg-white dark:bg-neutral-800 rounded-lg shadow-soft dark:shadow-none border border-neutral-200 dark:border-neutral-700;
   }
+
+  .animate-fadeIn {
+    animation: fadeIn 0.5s ease-in-out;
+  }
+}
+
+@keyframes fadeIn {
+  from {
+    opacity: 0;
+    transform: translateY(10px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 .moon-dance-regular {
   font-family: "Moon Dance", cursive;

--- a/src/pages/Dashboard.jsx
+++ b/src/pages/Dashboard.jsx
@@ -5,6 +5,7 @@ import MoodTracker from "../components/dashboard/MoodTracker";
 //import MoodChart from "../components/dashboard/MoodChart";
 import MoodTrendChart from "../components/dashboard/MoodTrendChart";
 import AffirmationBanner from "../components/dashboard/AffirmationBanner";
+import Heatmap from "../components/dashboard/Heatmap";
 import { format } from "date-fns";
 
 const Dashboard = () => {
@@ -33,7 +34,7 @@ const Dashboard = () => {
   });
 
   return (
-    <div className="space-y-6 animate-fadeIn">
+    <div className="calming-bg min-h-screen space-y-6 animate-fadeIn">
       <div>
         <h1 className="text-2xl md:text-3xl font-libre-baskerville font-bold text-neutral-900 dark:text-white">
           Welcome, {user.name}
@@ -82,6 +83,8 @@ const Dashboard = () => {
       </div>
 
       <MoodTrendChart />
+
+      <Heatmap />
 
       <RecentEntries />
     </div>


### PR DESCRIPTION
### What I Did
- Implemented a new **Mood Heatmap** to visualize emotional patterns over time.
- Added **color-coded cells** for moods (Great, Good, Okay, Bad, Awful).
- Integrated **tooltips** that display mood details and date on hover.
- Included a **color legend** for better user understanding.
- Updated `Dashboard.jsx` to include the Heatmap component.

### Why This Change?
This feature provides a visual overview of mood trends, helping users quickly identify patterns in their emotional well-being.

### How to Test
1. Go to the Dashboard.
2. Check the new Mood Heatmap.
3. Hover over cells to view mood details.
4. Verify that the color legend appears below the heatmap

![heatmap](https://github.com/user-attachments/assets/6a650cba-02c0-4b22-98e4-c9197bcaf094)
.

### Notes
- Fully responsive and works across **week, month, and year** filters.
- No breaking changes introduced.

