### PR TITLE
feat: enhance recent journal entries with card layout and responsiveness

### DIFF
--- a/src/components/dashboard/RecentEntries.jsx
+++ b/src/components/dashboard/RecentEntries.jsx
@@ -5,13 +5,12 @@ import MoodIcon from "../journal/MoodIcon";
 
 const RecentEntries = () => {
   const { entries, privateEntryIds } = useJournal();
+  const publicEntries = entries.filter(
+    (entry) => !privateEntryIds.includes(entry.id)
+  );
+  const recentEntries = publicEntries.slice(0, 6);
 
-  // Get the 5 most recent public entries
-  const recentEntries = entries
-    .filter(entry => !privateEntryIds.includes(entry.id))
-    .slice(0, 5);
-
-  if (entries.filter(entry => !privateEntryIds.includes(entry.id)).length === 0) {
+  if (publicEntries.length === 0) {
     return (
       <div className="card p-4">
         <h2 className="text-lg font-medium mb-4">Recent Entries</h2>
@@ -31,11 +30,10 @@ const RecentEntries = () => {
   }
 
   return (
-    <div className="card">
-      <div className="flex justify-between items-center px-4 pt-4 pb-2">
-        <h2 className="text-lg text-xl font-lora font-semibold">
-          Recent Entries
-        </h2>
+    <div className="card p-4">
+      {/* Header */}
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-lg font-lora font-semibold">Recent Entries</h2>
         <Link
           to="/journal"
           className="font-lora font-medium text-sm text-primary-600 dark:text-primary-400 hover:text-primary-700 dark:hover:text-primary-300"
@@ -44,40 +42,70 @@ const RecentEntries = () => {
         </Link>
       </div>
 
-      <div className="divide-y divide-neutral-200 dark:divide-neutral-700">
+      {/* Responsive Grid */}
+      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
         {recentEntries.map((entry) => (
-          <Link
-            key={entry.id}
-            to={`/journal/${entry.id}`}
-            className="block px-4 py-3 hover:bg-neutral-50 dark:hover:bg-neutral-700 transition-colors"
-          >
-            <div className="flex justify-between">
-              <h3 className="font-libre-baskerville font-medium text-neutral-800 dark:text-neutral-100 mb-1 truncate pr-4">
-                {entry.title}
-              </h3>
-              <MoodIcon mood={entry.mood} />
-            </div>
-            <p className="font-lora text-sm text-neutral-500 dark:text-neutral-300 mb-1">
-              {format(new Date(entry.createdAt), "PPP")}
-            </p>
-            <p className="font-lora font-medium text-neutral-600 dark:text-neutral-200 text-sm line-clamp-1">
-              {entry.content}
-            </p>
-          </Link>
+          <EntryCard key={entry.id} entry={entry} />
         ))}
       </div>
 
-      {entries.length > 0 && (
-        <div className="p-4 border-t border-neutral-200 dark:border-neutral-700">
-          <Link
-            to="/journal/new"
-            className="font-lora font-light btn btn-primary w-full"
-          >
-            New Journal Entry
-          </Link>
-        </div>
-      )}
+      {/* New Entry Button */}
+      <div className="mt-6">
+        <Link to="/journal/new" className="btn btn-primary w-full font-lora">
+          New Journal Entry
+        </Link>
+      </div>
     </div>
+  );
+};
+
+// Mood-based hover styles
+const getMoodHover = (mood) => {
+  switch (mood) {
+    case "great":
+      return "hover:border-emerald-400 hover:shadow-emerald-300/40";
+    case "good":
+      return "hover:border-blue-400 hover:shadow-blue-300/40";
+    case "okay":
+      return "hover:border-slate-400 hover:shadow-slate-300/40";
+    case "bad":
+      return "hover:border-amber-400 hover:shadow-amber-300/40";
+    case "awful":
+      return "hover:border-rose-400 hover:shadow-rose-300/40";
+    default:
+      return "hover:border-neutral-400 hover:shadow-neutral-300/40";
+  }
+};
+
+// Reusable Card Component
+const EntryCard = ({ entry }) => {
+  return (
+    <Link
+      to={`/journal/${entry.id}`}
+      className={`group rounded-xl border border-neutral-200 dark:border-neutral-700 p-4 bg-white dark:bg-neutral-800 shadow-sm transition-all duration-300 hover:-translate-y-1 hover:shadow-lg ${getMoodHover(
+        entry.mood
+      )}`}
+    >
+      {/* Date & Mood */}
+      <div className="flex items-center justify-between mb-2">
+        <p className="text-xs text-neutral-500 dark:text-neutral-400">
+          {format(new Date(entry.createdAt), "PPP")}
+        </p>
+        <div className="transform transition-transform duration-200 group-hover:scale-110">
+          <MoodIcon mood={entry.mood} />
+        </div>
+      </div>
+
+      {/* Title */}
+      <h3 className="font-libre-baskerville text-neutral-800 dark:text-neutral-100 font-medium text-lg truncate">
+        {entry.title || "Untitled Entry"}
+      </h3>
+
+      {/* Preview */}
+      <p className="font-lora text-sm text-neutral-600 dark:text-neutral-300 mt-1 line-clamp-2">
+        {entry.content || "No content available"}
+      </p>
+    </Link>
   );
 };
 


### PR DESCRIPTION
### What I Did
- Enhanced Recent Journal Entries by displaying them in a card layout.
- Each card shows the date, mood icon, and a short preview of the journal.
- Added professional hover effects and improved overall styling.
- Made the section fully responsive across desktop and mobile.

### How to Test
1. Go to Dashboard.
2. Check the Recent Journal Entries section.
3. Resize the screen (desktop → mobile) to confirm responsiveness.
4. Hover over cards to see effects.

### Screenshots

![journals](https://github.com/user-attachments/assets/5552693b-a55a-4c09-bb77-e9870a0a20ed)

